### PR TITLE
Use AxisAlignedBB.grow instead of AxisAlignedBB.expand

### DIFF
--- a/src/main/java/com/lulan/shincolle/ai/EntityAIShipGuarding.java
+++ b/src/main/java/com/lulan/shincolle/ai/EntityAIShipGuarding.java
@@ -336,7 +336,7 @@ public class EntityAIShipGuarding extends EntityAIBase
 	//find target
 	private void findTarget()
 	{
-		List<EntityLivingBase> list1 = this.host2.world.getEntitiesWithinAABB(EntityLivingBase.class, this.host2.getEntityBoundingBox().expand(this.range * 0.9D, this.range * 0.6D, this.range * 0.9D), this.targetSelector);
+		List<EntityLivingBase> list1 = this.host2.world.getEntitiesWithinAABB(EntityLivingBase.class, this.host2.getEntityBoundingBox().grow(this.range * 0.9D, this.range * 0.6D, this.range * 0.9D), this.targetSelector);
         
         //sort target list
         Collections.sort(list1, this.targetSorter);

--- a/src/main/java/com/lulan/shincolle/ai/EntityAIShipPickItem.java
+++ b/src/main/java/com/lulan/shincolle/ai/EntityAIShipPickItem.java
@@ -191,7 +191,7 @@ public class EntityAIShipPickItem extends EntityAIBase
         List<EntityItem> getlist = null;
         
         getlist = this.hostShip.world.getEntitiesWithinAABB(EntityItem.class, 
-        			this.hostShip.getEntityBoundingBox().expand(this.pickRange, this.pickRange * 0.5F + 1F, this.pickRange));
+        			this.hostShip.getEntityBoundingBox().grow(this.pickRange, this.pickRange * 0.5F + 1F, this.pickRange));
         
         //get random item
         if (getlist != null && !getlist.isEmpty())

--- a/src/main/java/com/lulan/shincolle/ai/EntityAIShipRangeAttack.java
+++ b/src/main/java/com/lulan/shincolle/ai/EntityAIShipRangeAttack.java
@@ -14,19 +14,19 @@ import net.minecraft.entity.ai.EntityAIBase;
  */
 public class EntityAIShipRangeAttack extends EntityAIBase
 {
-	
-    private IShipCannonAttack host;  	//AI host entity
+    
+    private IShipCannonAttack host;      //AI host entity
     private EntityLiving host2;
-    private Entity target;  			//entity of target
-    private int delayLight;				//light attack delay
-    private int maxDelayLight;	    	//light attack max delay
-    private int delayHeavy;				//heavy attack delay
-    private int maxDelayHeavy;	    	//heavy attack max delay (= light delay x5)    
-    private int onSightTime;			//target on sight time
-    private float range;				//attack range
-    private float rangeSq;				//attack range square
-    private int aimTime;				//time before fire
-    private double distSq, distSqrt, distX, distY, distZ;	//跟目標的直線距離(的平方)
+    private Entity target;              //entity of target
+    private int delayLight;                //light attack delay
+    private int maxDelayLight;            //light attack max delay
+    private int delayHeavy;                //heavy attack delay
+    private int maxDelayHeavy;            //heavy attack max delay (= light delay x5)    
+    private int onSightTime;            //target on sight time
+    private float range;                //attack range
+    private float rangeSq;                //attack range square
+    private int aimTime;                //time before fire
+    private double distSq, distSqrt, distX, distY, distZ;    //跟目標的直線距離(的平方)
     
     
     //parm: host, move speed, p4, attack delay, p6
@@ -52,36 +52,36 @@ public class EntityAIShipRangeAttack extends EntityAIBase
 
     //check ai start condition
     @Override
-	public boolean shouldExecute()
+    public boolean shouldExecute()
     {
-    	//for entity ship
-    	if (host2 != null)
-    	{
-    		//坐下, 裝載中不攻擊
-    		if (host.getIsSitting() || host.getStateMinor(ID.M.CraneState) > 0)
-    		{
-    			return false;
-    		}
-    		
-    		//若騎乘ship類座騎, 則攻擊交給mount判定
-    		if (this.host.getIsRiding())
-    		{
-    			if (this.host2.getRidingEntity() instanceof BasicEntityMount)
-    			{
-    				return false;
-    			}
-    		}
-        	
-        	Entity target = this.host.getEntityTarget();
-        	
+        //for entity ship
+        if (host2 != null)
+        {
+            //坐下, 裝載中不攻擊
+            if (host.getIsSitting() || host.getStateMinor(ID.M.CraneState) > 0)
+            {
+                return false;
+            }
+            
+            //若騎乘ship類座騎, 則攻擊交給mount判定
+            if (this.host.getIsRiding())
+            {
+                if (this.host2.getRidingEntity() instanceof BasicEntityMount)
+                {
+                    return false;
+                }
+            }
+            
+            Entity target = this.host.getEntityTarget();
+            
             if (target != null && target.isEntityAlive() &&
-            	((this.host.getAttackType(ID.F.AtkType_Light) && this.host.getStateFlag(ID.F.UseAmmoLight) && this.host.hasAmmoLight()) || 
-            	 (this.host.getAttackType(ID.F.AtkType_Heavy) && this.host.getStateFlag(ID.F.UseAmmoHeavy) && this.host.hasAmmoHeavy())))
+                ((this.host.getAttackType(ID.F.AtkType_Light) && this.host.getStateFlag(ID.F.UseAmmoLight) && this.host.hasAmmoLight()) || 
+                 (this.host.getAttackType(ID.F.AtkType_Heavy) && this.host.getStateFlag(ID.F.UseAmmoHeavy) && this.host.hasAmmoHeavy())))
             {   
-            	this.target = target;
+                this.target = target;
                 return true;
             }
-    	}       
+        }       
         
         return false;
     }
@@ -90,45 +90,45 @@ public class EntityAIShipRangeAttack extends EntityAIBase
     @Override
     public void startExecuting()
     {
-    	if (host != null)
-    	{
-    		this.updateAttackParms();
-	    	
-	    	//if target changed, check the delay time from prev attack
-	    	if (this.delayLight <= this.aimTime)
-	    	{
-	    		this.delayLight = this.aimTime;
-	    	}
-	    	
-	    	if (this.delayHeavy <= this.aimTime * 2)
-	    	{
-	    		this.delayHeavy = this.aimTime * 2;
-	    	}
-	        
-	        distSq = distX = distY = distZ = 0D;
-    	}      
+        if (host != null)
+        {
+            this.updateAttackParms();
+            
+            //if target changed, check the delay time from prev attack
+            if (this.delayLight <= this.aimTime)
+            {
+                this.delayLight = this.aimTime;
+            }
+            
+            if (this.delayHeavy <= this.aimTime * 2)
+            {
+                this.delayHeavy = this.aimTime * 2;
+            }
+            
+            distSq = distX = distY = distZ = 0D;
+        }      
     }
 
     //判定是否繼續AI： 有target就繼續, 或者已經移動完畢就繼續
     @Override
-	public boolean shouldContinueExecuting()
+    public boolean shouldContinueExecuting()
     {
-    	if (host != null)
-    	{
-    		if (target != null && target.isEntityAlive() && !this.host.getShipNavigate().noPath())
-    		{
-        		return true;
-        	}
-        	
+        if (host != null)
+        {
+            if (target != null && target.isEntityAlive() && !this.host.getShipNavigate().noPath())
+            {
+                return true;
+            }
+            
             return this.shouldExecute();
-    	}
-    	
-    	return false;
+        }
+        
+        return false;
     }
 
     //重置AI方法
     @Override
-	public void resetTask()
+    public void resetTask()
     {
         this.target = null;
         this.onSightTime = 0;
@@ -136,98 +136,98 @@ public class EntityAIShipRangeAttack extends EntityAIBase
 
     //進行AI
     @Override
-	public void updateTask()
+    public void updateTask()
     {
-    	boolean onSight = false;	//判定直射是否無障礙物
-    	
-    	if (this.host != null && this.target != null)
-    	{
-    		//get update attributes every second
-    		if (this.host2.ticksExisted % 64 == 0)
-    		{
-    			this.updateAttackParms();
-    		}
+        boolean onSight = false;    //判定直射是否無障礙物
+        
+        if (this.host != null && this.target != null)
+        {
+            //get update attributes every second
+            if (this.host2.ticksExisted % 64 == 0)
+            {
+                this.updateAttackParms();
+            }
 
-    		//delay time decr
-	        this.delayLight--;
-	        this.delayHeavy--;
+            //delay time decr
+            this.delayLight--;
+            this.delayHeavy--;
 
-    		this.distX = this.target.posX - this.host2.posX;
-    		this.distY = this.target.posY - this.host2.posY;
-    		this.distZ = this.target.posZ - this.host2.posZ;	
-    		this.distSq = distX*distX + distY*distY + distZ*distZ;
-    		    		
+            this.distX = this.target.posX - this.host2.posX;
+            this.distY = this.target.posY - this.host2.posY;
+            this.distZ = this.target.posZ - this.host2.posZ;    
+            this.distSq = distX*distX + distY*distY + distZ*distZ;
+                        
             onSight = this.host2.getEntitySenses().canSee(this.target);
 
-	        //可直視, 則on sight time++, 否則重置為0
-	        if (onSight)
-	        {
-	            ++this.onSightTime;
-	        }
-	        else
-	        {
-	            this.onSightTime = 0;
-	            
-	            //若host要求onSight, 則看不到時馬上放棄目標, 停止AI
-	            if (host.getStateFlag(ID.F.OnSightChase))
-	            {
-	            	this.resetTask();
-	            	return;
-	            }
-	        }
-	
-	        //若目標進入射程, 且目標無障礙物阻擋, 則清空AI移動的目標, 以停止繼續移動      
-	        if (distSq < this.rangeSq && onSight && !host.getStateFlag(ID.F.UseMelee))
-	        {
-	        	this.host.getShipNavigate().clearPath();
-	        }
-	        else
-	        {	//目標移動, 則繼續追
-	        	if (host2.ticksExisted % 32 == 0)
-	        	{
-	        		this.host.getShipNavigate().tryMoveToEntityLiving(this.target, 1D);
-	        	}
+            //可直視, 則on sight time++, 否則重置為0
+            if (onSight)
+            {
+                ++this.onSightTime;
             }
-	        
-	        //設定攻擊時, 頭部觀看的角度
-	        this.host2.getLookHelper().setLookPositionWithEntity(this.target, 30F, 30F);
+            else
+            {
+                this.onSightTime = 0;
+                
+                //若host要求onSight, 則看不到時馬上放棄目標, 停止AI
+                if (host.getStateFlag(ID.F.OnSightChase))
+                {
+                    this.resetTask();
+                    return;
+                }
+            }
+    
+            //若目標進入射程, 且目標無障礙物阻擋, 則清空AI移動的目標, 以停止繼續移動      
+            if (distSq < this.rangeSq && onSight && !host.getStateFlag(ID.F.UseMelee))
+            {
+                this.host.getShipNavigate().clearPath();
+            }
+            else
+            {    //目標移動, 則繼續追
+                if (host2.ticksExisted % 32 == 0)
+                {
+                    this.host.getShipNavigate().tryMoveToEntityLiving(this.target, 1D);
+                }
+            }
+            
+            //設定攻擊時, 頭部觀看的角度
+            this.host2.getLookHelper().setLookPositionWithEntity(this.target, 30F, 30F);
 
-	        //若attack delay倒數完了且瞄準時間夠久, 則開始攻擊
-	        if (onSight && distSq <= this.rangeSq && this.onSightTime >= this.aimTime)
-	        {
-	        	//使用輕攻擊
-	        	if (this.delayLight <= 0 && this.host.useAmmoLight() && this.host.hasAmmoLight())
-	        	{
-	        		this.host.attackEntityWithAmmo(this.target);
-		            this.delayLight = this.maxDelayLight;
-	        	}
-	        	
-	        	//使用重攻擊
-	        	if (this.delayHeavy <= 0 && this.host.useAmmoHeavy() && this.host.hasAmmoHeavy())
-	        	{
-	        		this.host.attackEntityWithHeavyAmmo(this.target);
-		            this.delayHeavy = this.maxDelayHeavy;
-	        	}
-	        }
-	        
-	        //若超過太久都打不到目標(或是追不到), 則重置目標
-	        if (this.delayHeavy < -40 && this.delayLight < -40)
-	        {
-	        	this.delayLight = 20;
-	        	this.delayHeavy = 20;
-	        	this.resetTask();
-	        	return;
-	        }
+            //若attack delay倒數完了且瞄準時間夠久, 則開始攻擊
+            if (onSight && distSq <= this.rangeSq && this.onSightTime >= this.aimTime)
+            {
+                //使用輕攻擊
+                if (this.delayLight <= 0 && this.host.useAmmoLight() && this.host.hasAmmoLight())
+                {
+                    this.host.attackEntityWithAmmo(this.target);
+                    this.delayLight = this.maxDelayLight;
+                }
+                
+                //使用重攻擊
+                if (this.delayHeavy <= 0 && this.host.useAmmoHeavy() && this.host.hasAmmoHeavy())
+                {
+                    this.host.attackEntityWithHeavyAmmo(this.target);
+                    this.delayHeavy = this.maxDelayHeavy;
+                }
+            }
+            
+            //若超過太久都打不到目標(或是追不到), 則重置目標
+            if (this.delayHeavy < -40 && this.delayLight < -40)
+            {
+                this.delayLight = 20;
+                this.delayHeavy = 20;
+                this.resetTask();
+                return;
+            }
 
-    	}//end target != null
+        }//end target != null
     }//end update task
     
     private void updateAttackParms()
     {
-    	this.maxDelayLight = CombatHelper.getAttackDelay(this.host.getAttrs().getAttackSpeed(), 1);
-    	this.maxDelayHeavy = CombatHelper.getAttackDelay(this.host.getAttrs().getAttackSpeed(), 2);
-    	this.aimTime = (int) (20F * (150 - this.host.getLevel()) / 150F) + 10;
-    	this.range = this.host.getAttrs().getAttackRange();
+        this.maxDelayLight = CombatHelper.getAttackDelay(this.host.getAttrs().getAttackSpeed(), 1);
+        this.maxDelayHeavy = CombatHelper.getAttackDelay(this.host.getAttrs().getAttackSpeed(), 2);
+        this.aimTime = (int) (20F * (150 - this.host.getLevel()) / 150F) + 10;
+        this.range = this.host.getAttrs().getAttackRange();
         this.rangeSq = this.range * this.range;
     }
     

--- a/src/main/java/com/lulan/shincolle/ai/EntityAIShipRangeTarget.java
+++ b/src/main/java/com/lulan/shincolle/ai/EntityAIShipRangeTarget.java
@@ -29,7 +29,7 @@ import net.minecraft.entity.player.EntityPlayer;
  */
 public class EntityAIShipRangeTarget extends EntityAIBase
 {
-	
+    
     protected Class targetClass;
     protected TargetHelper.Sorter targetSorter;
     protected Predicate targetSelector;
@@ -43,26 +43,26 @@ public class EntityAIShipRangeTarget extends EntityAIBase
     //將maxRange 乘上一個比例當作range1
     public EntityAIShipRangeTarget(IShipAttackBase host, Class targetClass)
     {
-    	this.setMutexBits(1);
-    	this.host = host;
-    	this.host2 = (EntityLiving) host;
-    	
+        this.setMutexBits(1);
+        this.host = host;
+        this.host2 = (EntityLiving) host;
+        
         //攻擊類型指定
         this.targetClass = targetClass;
         this.targetSorter = new TargetHelper.Sorter(host2);
         
         if (host instanceof BasicEntityShipHostile)
         {
-        	this.targetSelector = new TargetHelper.SelectorForHostile(host2);
+            this.targetSelector = new TargetHelper.SelectorForHostile(host2);
         }
         else if (host instanceof BasicEntityShip)
         {
-        	this.hostShip = (BasicEntityShip) host;
-    		this.targetSelector = new TargetHelper.Selector(host2);
+            this.hostShip = (BasicEntityShip) host;
+            this.targetSelector = new TargetHelper.Selector(host2);
         }
         else
         {
-        	this.targetSelector = new TargetHelper.Selector(host2);
+            this.targetSelector = new TargetHelper.Selector(host2);
         }
 
         //範圍設定
@@ -72,17 +72,17 @@ public class EntityAIShipRangeTarget extends EntityAIBase
     @Override
     public boolean shouldExecute()
     {
-    	//update range
-    	if (host != null)
-    	{
-    		//check every 8 ticks
-        	if (host.getIsSitting() || host.getStateMinor(ID.M.CraneState) > 0 ||
-        	   host.getTickExisted() % 8 != 0)
-        	{
-        		return false;
-        	}
-    		
-        	updateRange();
+        //update range
+        if (host != null)
+        {
+            //check every 8 ticks
+            if (host.getIsSitting() || host.getStateMinor(ID.M.CraneState) > 0 ||
+               host.getTickExisted() % 8 != 0)
+            {
+                return false;
+            }
+            
+            updateRange();
             
             //find target
             ArrayList list1 = null;
@@ -90,67 +90,67 @@ public class EntityAIShipRangeTarget extends EntityAIBase
             
             if (this.hostShip != null)
             {  //ship: pvp, AA, ASM mode
-            	//Anti Air first
-            	if (this.hostShip.getStateFlag(ID.F.AntiAir))
-            	{
-            		//find air target
-            		list1 = EntityHelper.getEntitiesWithinAABB(this.host2.world, IShipFlyable.class,
-            				this.host2.getEntityBoundingBox().expand(this.range, this.range * 0.75D, this.range), this.targetSelector);
-            		list2 = (ArrayList) this.host2.world.getEntitiesWithinAABB(EntityFlying.class,
-                    		this.host2.getEntityBoundingBox().expand(this.range, this.range * 0.75D, this.range), this.targetSelector);
-            		
-            		//union list
-            		list1 = CalcHelper.listUnion(list1, list2);
-            	}
-            	
-            	//if no AA target, find ASM target
-            	if (list1 == null || list1.isEmpty())
-            	{
-            		if (this.hostShip.getStateFlag(ID.F.AntiSS))
-            		{
-        				list1 = EntityHelper.getEntitiesWithinAABB(this.host2.world, IShipInvisible.class, 
-                        		this.host2.getEntityBoundingBox().expand(this.range, this.range * 0.75D, this.range), this.targetSelector);
-                	}
-            		
-            		//find PVP target
-            		if (list1 == null || list1.isEmpty())
-            		{
-                    	if (this.hostShip.getStateFlag(ID.F.PVPFirst))
-                    	{
-                    		list1 = (ArrayList) this.host2.world.getEntitiesWithinAABB(BasicEntityShip.class, 
-                            		this.host2.getEntityBoundingBox().expand(this.range, this.range * 0.75D, this.range), this.targetSelector);
-                    	}
-            		}
-            	}
+                //Anti Air first
+                if (this.hostShip.getStateFlag(ID.F.AntiAir))
+                {
+                    //find air target
+                    list1 = EntityHelper.getEntitiesWithinAABB(this.host2.world, IShipFlyable.class,
+                            this.host2.getEntityBoundingBox().grow(this.range, this.range * 0.75D, this.range), this.targetSelector);
+                    list2 = (ArrayList) this.host2.world.getEntitiesWithinAABB(EntityFlying.class,
+                            this.host2.getEntityBoundingBox().grow(this.range, this.range * 0.75D, this.range), this.targetSelector);
+                    
+                    //union list
+                    list1 = CalcHelper.listUnion(list1, list2);
+                }
+                
+                //if no AA target, find ASM target
+                if (list1 == null || list1.isEmpty())
+                {
+                    if (this.hostShip.getStateFlag(ID.F.AntiSS))
+                    {
+                        list1 = EntityHelper.getEntitiesWithinAABB(this.host2.world, IShipInvisible.class, 
+                                this.host2.getEntityBoundingBox().grow(this.range, this.range * 0.75D, this.range), this.targetSelector);
+                    }
+                    
+                    //find PVP target
+                    if (list1 == null || list1.isEmpty())
+                    {
+                        if (this.hostShip.getStateFlag(ID.F.PVPFirst))
+                        {
+                            list1 = (ArrayList) this.host2.world.getEntitiesWithinAABB(BasicEntityShip.class, 
+                                    this.host2.getEntityBoundingBox().grow(this.range, this.range * 0.75D, this.range), this.targetSelector);
+                        }
+                    }
+                }
             }//end host is ship
             
             //find normal target
             if (list1 == null || list1.isEmpty())
             {
-	        	list1 = EntityHelper.getEntitiesWithinAABB(this.host2.world, this.targetClass, 
-	            		this.host2.getEntityBoundingBox().expand(this.range, this.range * 0.75D, this.range), this.targetSelector);
+                list1 = EntityHelper.getEntitiesWithinAABB(this.host2.world, this.targetClass, 
+                        this.host2.getEntityBoundingBox().grow(this.range, this.range * 0.75D, this.range), this.targetSelector);
             }
             
             //若有抓到target
             if (list1 != null && !list1.isEmpty())
             {
-            	//對目標做distance sort, nearest target排最前面
+                //對目標做distance sort, nearest target排最前面
                 Collections.sort(list1, this.targetSorter);
 
-            	//get nearest target
-            	this.targetEntity = (Entity) list1.get(0);
-            	
-            	//get random 0~2 target if >2 targets
-            	if (list1.size() > 2)
-            	{
-            		this.targetEntity = (Entity) list1.get(this.host2.world.rand.nextInt(3));
-            	}
-            	
+                //get nearest target
+                this.targetEntity = (Entity) list1.get(0);
+                
+                //get random 0~2 target if >2 targets
+                if (list1.size() > 2)
+                {
+                    this.targetEntity = (Entity) list1.get(this.host2.world.rand.nextInt(3));
+                }
+                
                 return true;
             }//end list not null
-    	}//end host not null
-    	
-    	return false;
+        }//end host not null
+        
+        return false;
     }
     
     @Override
@@ -159,8 +159,8 @@ public class EntityAIShipRangeTarget extends EntityAIBase
     @Override
     public void startExecuting()
     {
-//    	LogHelper.info("DEBUG : target AI: "+this.host+"   "+this.targetEntity);
-    	if(this.host != null) this.host.setEntityTarget(this.targetEntity);
+//        LogHelper.info("DEBUG : target AI: "+this.host+"   "+this.targetEntity);
+        if(this.host != null) this.host.setEntityTarget(this.targetEntity);
     }
     
     @Override
@@ -195,13 +195,13 @@ public class EntityAIShipRangeTarget extends EntityAIBase
     
     private void updateRange()
     {
-    	 this.range = (int) this.host.getAttrs().getAttackRange();
+         this.range = (int) this.host.getAttrs().getAttackRange();
          
-    	 //min range
-    	 if (this.range < 2)
-    	 {
-    		 this.range = Math.max(2, host.getStateMinor(ID.M.FollowMax) + 2);
-    	 }
+         //min range
+         if (this.range < 2)
+         {
+             this.range = Math.max(2, host.getStateMinor(ID.M.FollowMax) + 2);
+         }
     }
     
     

--- a/src/main/java/com/lulan/shincolle/entity/BasicEntityAirplane.java
+++ b/src/main/java/com/lulan/shincolle/entity/BasicEntityAirplane.java
@@ -207,13 +207,13 @@ abstract public class BasicEntityAirplane extends BasicEntitySummon implements I
 						//if host Anti-Air, find airplane every 32 ticks
 						if (this.host.getStateFlag(ID.F.AntiAir))
 						{
-							list = this.world.getEntitiesWithinAABB(BasicEntityAirplane.class, this.getEntityBoundingBox().expand(32D, 32D, 32D), this.targetSelector);
+							list = this.world.getEntitiesWithinAABB(BasicEntityAirplane.class, this.getEntityBoundingBox().grow(32D, 32D, 32D), this.targetSelector);
 						}
 						
 						//find new target if "target dead" or "no air target"
 						if (list == null || list.isEmpty())
 						{
-							list = this.world.getEntitiesWithinAABB(Entity.class, this.getEntityBoundingBox().expand(24D, 24D, 24D), this.targetSelector);
+							list = this.world.getEntitiesWithinAABB(Entity.class, this.getEntityBoundingBox().grow(24D, 24D, 24D), this.targetSelector);
 						}
 				        
 				        //get target in list

--- a/src/main/java/com/lulan/shincolle/entity/battleship/EntityBBHaruna.java
+++ b/src/main/java/com/lulan/shincolle/entity/battleship/EntityBBHaruna.java
@@ -96,7 +96,7 @@ public class EntityBBHaruna extends BasicEntityShipSmall
   				if (getStateFlag(ID.F.IsMarried) && getStateFlag(ID.F.UseRingEffect) &&
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   	  	  			
   					if (shiplist != null && shiplist.size() > 0)
   					{

--- a/src/main/java/com/lulan/shincolle/entity/battleship/EntityBBHiei.java
+++ b/src/main/java/com/lulan/shincolle/entity/battleship/EntityBBHiei.java
@@ -95,7 +95,7 @@ public class EntityBBHiei extends BasicEntityShipSmall
   				if (getStateFlag(ID.F.IsMarried) && getStateFlag(ID.F.UseRingEffect) &&
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   	  	  			
   					if (shiplist != null && shiplist.size() > 0)
   					{

--- a/src/main/java/com/lulan/shincolle/entity/battleship/EntityBBKirishima.java
+++ b/src/main/java/com/lulan/shincolle/entity/battleship/EntityBBKirishima.java
@@ -92,7 +92,7 @@ public class EntityBBKirishima extends BasicEntityShipSmall
   				if (getStateFlag(ID.F.IsMarried) && getStateFlag(ID.F.UseRingEffect) &&
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   	  	  			
   					if (shiplist != null && shiplist.size() > 0)
   					{

--- a/src/main/java/com/lulan/shincolle/entity/battleship/EntityBBKongou.java
+++ b/src/main/java/com/lulan/shincolle/entity/battleship/EntityBBKongou.java
@@ -97,7 +97,7 @@ public class EntityBBKongou extends BasicEntityShipSmall
   				if (getStateFlag(ID.F.IsMarried) && getStateFlag(ID.F.UseRingEffect) &&
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   	  	  			
   					if (shiplist != null && shiplist.size() > 0)
   					{

--- a/src/main/java/com/lulan/shincolle/entity/battleship/EntityBattleshipNGT.java
+++ b/src/main/java/com/lulan/shincolle/entity/battleship/EntityBattleshipNGT.java
@@ -114,7 +114,7 @@ public class EntityBattleshipNGT extends BasicEntityShipSmall
   				if (getStateFlag(ID.F.IsMarried) && getStateFlag(ID.F.UseRingEffect) &&
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   	  	  			
   					if (shiplist != null && shiplist.size() > 0)
   					{
@@ -138,7 +138,7 @@ public class EntityBattleshipNGT extends BasicEntityShipSmall
   		if (host.isMorph()) return;
   		
 		//get nearby ship
-		List<EntityLivingBase> slist = host.world.getEntitiesWithinAABB(EntityLivingBase.class, host.getEntityBoundingBox().expand(16D, 12D, 16D));
+		List<EntityLivingBase> slist = host.world.getEntitiesWithinAABB(EntityLivingBase.class, host.getEntityBoundingBox().grow(16D, 12D, 16D));
 		List<EntityLivingBase> target = new ArrayList<EntityLivingBase>();
 		
 		if (slist != null && !slist.isEmpty())
@@ -282,7 +282,7 @@ public class EntityBattleshipNGT extends BasicEntityShipSmall
       		
       		//對範圍造成atk2傷害
             Entity hitEntity = null;
-            AxisAlignedBB impactBox = this.getEntityBoundingBox().expand(3.5D, 3.5D, 3.5D); 
+            AxisAlignedBB impactBox = this.getEntityBoundingBox().grow(3.5D, 3.5D, 3.5D); 
             List<Entity> hitList = this.world.getEntitiesWithinAABB(Entity.class, impactBox);
             float atkTemp = atk2;
             

--- a/src/main/java/com/lulan/shincolle/entity/battleship/EntityBattleshipNGTMob.java
+++ b/src/main/java/com/lulan/shincolle/entity/battleship/EntityBattleshipNGTMob.java
@@ -198,7 +198,7 @@ public class EntityBattleshipNGTMob extends BasicEntityShipHostile
       		//對範圍造成atk2傷害
   			Entity hitEntity = null;
             double range = 3.5D + this.scaleLevel * 0.5D;
-            AxisAlignedBB impactBox = this.getEntityBoundingBox().expand(range, range, range); 
+            AxisAlignedBB impactBox = this.getEntityBoundingBox().grow(range, range, range); 
             List<Entity> hitList = this.world.getEntitiesWithinAABB(Entity.class, impactBox);
             float atkTemp = atk2;
             

--- a/src/main/java/com/lulan/shincolle/entity/battleship/EntityBattleshipRe.java
+++ b/src/main/java/com/lulan/shincolle/entity/battleship/EntityBattleshipRe.java
@@ -178,7 +178,7 @@ public class EntityBattleshipRe extends BasicEntityShipCV
     //find target to push
     private void findTargetPush()
     {
-        AxisAlignedBB impactBox = this.getEntityBoundingBox().expand(12D, 6D, 12D); 
+        AxisAlignedBB impactBox = this.getEntityBoundingBox().grow(12D, 6D, 12D); 
         List<EntityLivingBase> list = this.world.getEntitiesWithinAABB(EntityLivingBase.class, impactBox);
         
         //valid entity
@@ -205,7 +205,7 @@ public class EntityBattleshipRe extends BasicEntityShipCV
     		
             Entity hitEntity = null;
             //range = 3.5D
-            AxisAlignedBB impactBox = target.getEntityBoundingBox().expand(3.5D, 3.5D, 3.5D); 
+            AxisAlignedBB impactBox = target.getEntityBoundingBox().grow(3.5D, 3.5D, 3.5D); 
             List<Entity> hitList = this.world.getEntitiesWithinAABB(Entity.class, impactBox);
             //atk = 20% main target atk
             float atkTemp = atk * 0.2F;

--- a/src/main/java/com/lulan/shincolle/entity/battleship/EntityBattleshipTa.java
+++ b/src/main/java/com/lulan/shincolle/entity/battleship/EntityBattleshipTa.java
@@ -82,7 +82,7 @@ public class EntityBattleshipTa extends BasicEntityShip implements IShipSummonAt
   				if (getStateFlag(ID.F.IsMarried) && getStateFlag(ID.F.UseRingEffect) &&
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   	  	  			
   					if (shiplist != null && shiplist.size() > 0)
   					{

--- a/src/main/java/com/lulan/shincolle/entity/battleship/EntityBattleshipYMT.java
+++ b/src/main/java/com/lulan/shincolle/entity/battleship/EntityBattleshipYMT.java
@@ -113,7 +113,7 @@ public class EntityBattleshipYMT extends BasicEntityShipSmall
   				if (getStateFlag(ID.F.IsMarried) && getStateFlag(ID.F.UseRingEffect) &&
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   	  	  			
   					if (shiplist != null && shiplist.size() > 0)
   					{

--- a/src/main/java/com/lulan/shincolle/entity/carrier/EntityCarrierAkagi.java
+++ b/src/main/java/com/lulan/shincolle/entity/carrier/EntityCarrierAkagi.java
@@ -107,7 +107,7 @@ public class EntityCarrierAkagi extends BasicEntityShipCV
   				if (getStateFlag(ID.F.IsMarried) && getStateFlag(ID.F.UseRingEffect) &&
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   	  	  			
   					if (shiplist != null && shiplist.size() > 0)
   					{

--- a/src/main/java/com/lulan/shincolle/entity/carrier/EntityCarrierKaga.java
+++ b/src/main/java/com/lulan/shincolle/entity/carrier/EntityCarrierKaga.java
@@ -72,7 +72,7 @@ public class EntityCarrierKaga extends BasicEntityShipCV
   				if (getStateFlag(ID.F.IsMarried) && getStateFlag(ID.F.UseRingEffect) &&
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   	  	  			
   					if (shiplist != null && shiplist.size() > 0)
   					{

--- a/src/main/java/com/lulan/shincolle/entity/carrier/EntityCarrierWo.java
+++ b/src/main/java/com/lulan/shincolle/entity/carrier/EntityCarrierWo.java
@@ -146,7 +146,7 @@ public class EntityCarrierWo extends BasicEntityShipCV
   				if (getStateFlag(ID.F.IsMarried) && getStateFlag(ID.F.UseRingEffect) &&
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   	  	  			
   					if (shiplist != null && shiplist.size() > 0)
   					{

--- a/src/main/java/com/lulan/shincolle/entity/cruiser/EntityCANe.java
+++ b/src/main/java/com/lulan/shincolle/entity/cruiser/EntityCANe.java
@@ -160,7 +160,7 @@ public class EntityCANe extends BasicEntityShipSmall
     //find target to push
     private void findTargetPush()
     {
-        AxisAlignedBB impactBox = this.getEntityBoundingBox().expand(12D, 6D, 12D); 
+        AxisAlignedBB impactBox = this.getEntityBoundingBox().grow(12D, 6D, 12D); 
         List<EntityLivingBase> list = this.world.getEntitiesWithinAABB(EntityLivingBase.class, impactBox);
         
         //valid entity

--- a/src/main/java/com/lulan/shincolle/entity/cruiser/EntityCLTatsuta.java
+++ b/src/main/java/com/lulan/shincolle/entity/cruiser/EntityCLTatsuta.java
@@ -187,7 +187,7 @@ public class EntityCLTatsuta extends BasicEntityShipSmall
 		float rawatk = this.getAttackBaseDamage(2, null);
 		
 		ArrayList<Entity> list = EntityHelper.getEntitiesWithinAABB(this.world, Entity.class,
-				this.getEntityBoundingBox().expand(4D, 3D, 4D), this.targetSelector);
+				this.getEntityBoundingBox().grow(4D, 3D, 4D), this.targetSelector);
 
 		for (Entity target : list)
 		{
@@ -328,7 +328,7 @@ public class EntityCLTatsuta extends BasicEntityShipSmall
 				if (this.remainAttack > 0)
 				{
 					ArrayList<Entity> list = EntityHelper.getEntitiesWithinAABB(this.world, Entity.class,
-							this.getEntityBoundingBox().expand(16D, 16D, 16D), this.targetSelector);
+							this.getEntityBoundingBox().grow(16D, 16D, 16D), this.targetSelector);
 			
 					if (list.size() > 0)
 					{

--- a/src/main/java/com/lulan/shincolle/entity/cruiser/EntityCLTatsutaMob.java
+++ b/src/main/java/com/lulan/shincolle/entity/cruiser/EntityCLTatsutaMob.java
@@ -173,7 +173,7 @@ public class EntityCLTatsutaMob extends BasicEntityShipHostile
 		
 		TargetPoint point = new TargetPoint(this.dimension, this.posX, this.posY, this.posZ, 64D);
 		ArrayList<Entity> list = EntityHelper.getEntitiesWithinAABB(this.world, Entity.class,
-				this.getEntityBoundingBox().expand(4D, 3D, 4D), this.targetSelector);
+				this.getEntityBoundingBox().grow(4D, 3D, 4D), this.targetSelector);
 
 		for (Entity target : list)
 		{
@@ -297,7 +297,7 @@ public class EntityCLTatsutaMob extends BasicEntityShipHostile
 				if (this.remainAttack > 0)
 				{
 					ArrayList<Entity> list = EntityHelper.getEntitiesWithinAABB(this.world, Entity.class,
-							this.getEntityBoundingBox().expand(13D, 13D, 13D), this.targetSelector);
+							this.getEntityBoundingBox().grow(13D, 13D, 13D), this.targetSelector);
 			
 					if (list.size() > 0)
 					{

--- a/src/main/java/com/lulan/shincolle/entity/cruiser/EntityCLTenryuu.java
+++ b/src/main/java/com/lulan/shincolle/entity/cruiser/EntityCLTenryuu.java
@@ -209,7 +209,7 @@ public class EntityCLTenryuu extends BasicEntityShipSmall
 		float rawatk = this.getAttackBaseDamage(this.StateEmotion[ID.S.Phase] == 2 ? 2 : 3, null);
 		
 		ArrayList<Entity> list = EntityHelper.getEntitiesWithinAABB(this.world, Entity.class,
-				this.getEntityBoundingBox().expand(2D, 1.5D, 2D), this.targetSelector);
+				this.getEntityBoundingBox().grow(2D, 1.5D, 2D), this.targetSelector);
 
 		for (Entity target : list)
 		{
@@ -350,7 +350,7 @@ public class EntityCLTenryuu extends BasicEntityShipSmall
 				if (this.remainAttack > 0)
 				{
 					ArrayList<Entity> list = EntityHelper.getEntitiesWithinAABB(this.world, Entity.class,
-							this.getEntityBoundingBox().expand(10D, 10D, 10D), this.targetSelector);
+							this.getEntityBoundingBox().grow(10D, 10D, 10D), this.targetSelector);
 			
 					if (list.size() > 0)
 					{

--- a/src/main/java/com/lulan/shincolle/entity/cruiser/EntityCLTenryuuMob.java
+++ b/src/main/java/com/lulan/shincolle/entity/cruiser/EntityCLTenryuuMob.java
@@ -192,7 +192,7 @@ public class EntityCLTenryuuMob extends BasicEntityShipHostile
 		
 		TargetPoint point = new TargetPoint(this.dimension, this.posX, this.posY, this.posZ, 64D);
 		ArrayList<Entity> list = EntityHelper.getEntitiesWithinAABB(this.world, Entity.class,
-				this.getEntityBoundingBox().expand(1.5D, 1.5D, 1.5D), this.targetSelector);
+				this.getEntityBoundingBox().grow(1.5D, 1.5D, 1.5D), this.targetSelector);
 
 		for (Entity target : list)
 		{
@@ -314,7 +314,7 @@ public class EntityCLTenryuuMob extends BasicEntityShipHostile
 				if (this.remainAttack > 0)
 				{
 					ArrayList<Entity> list = EntityHelper.getEntitiesWithinAABB(this.world, Entity.class,
-							this.getEntityBoundingBox().expand(8D, 8D, 8D), this.targetSelector);
+							this.getEntityBoundingBox().grow(8D, 8D, 8D), this.targetSelector);
 			
 					if (list.size() > 0)
 					{

--- a/src/main/java/com/lulan/shincolle/entity/destroyer/EntityDestroyerAkatsuki.java
+++ b/src/main/java/com/lulan/shincolle/entity/destroyer/EntityDestroyerAkatsuki.java
@@ -273,7 +273,7 @@ public class EntityDestroyerAkatsuki extends BasicEntityShipSmall implements ISh
   			getStateMinor(ID.M.CraneState) == 0 && getStateMinor(ID.M.FormatType) == 1)
   		{
   			//get nearby ship
-  			List<BasicEntityShip> slist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(6D, 5D, 6D));
+  			List<BasicEntityShip> slist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(6D, 5D, 6D));
   			BasicEntityShip getHibiki = null;
   			BasicEntityShip getInazuma = null;
   			BasicEntityShip getIkazuchi = null;

--- a/src/main/java/com/lulan/shincolle/entity/destroyer/EntityDestroyerIkazuchi.java
+++ b/src/main/java/com/lulan/shincolle/entity/destroyer/EntityDestroyerIkazuchi.java
@@ -246,7 +246,7 @@ public class EntityDestroyerIkazuchi extends BasicEntityShipSmall implements ISh
 			getStateMinor(ID.M.CraneState) == 0)
 		{
 			//get nearby ship
-            List<EntityDestroyerInazuma> slist = this.world.getEntitiesWithinAABB(EntityDestroyerInazuma.class, this.getEntityBoundingBox().expand(4D, 4D, 4D));
+            List<EntityDestroyerInazuma> slist = this.world.getEntitiesWithinAABB(EntityDestroyerInazuma.class, this.getEntityBoundingBox().grow(4D, 4D, 4D));
 
             if (slist != null && !slist.isEmpty())
             {

--- a/src/main/java/com/lulan/shincolle/entity/destroyer/EntityDestroyerIkazuchiMob.java
+++ b/src/main/java/com/lulan/shincolle/entity/destroyer/EntityDestroyerIkazuchiMob.java
@@ -132,7 +132,7 @@ public class EntityDestroyerIkazuchiMob extends BasicEntityShipHostile implement
   		if (this.isRaiden) return;
 		
 		//get nearby ship
-        List<EntityDestroyerInazumaMob> slist = this.world.getEntitiesWithinAABB(EntityDestroyerInazumaMob.class, this.getEntityBoundingBox().expand(16D, 8D, 16D));
+        List<EntityDestroyerInazumaMob> slist = this.world.getEntitiesWithinAABB(EntityDestroyerInazumaMob.class, this.getEntityBoundingBox().grow(16D, 8D, 16D));
 
         if (slist != null && !slist.isEmpty())
         {

--- a/src/main/java/com/lulan/shincolle/entity/destroyer/EntityDestroyerInazuma.java
+++ b/src/main/java/com/lulan/shincolle/entity/destroyer/EntityDestroyerInazuma.java
@@ -284,7 +284,7 @@ public class EntityDestroyerInazuma extends BasicEntityShipSmall implements IShi
   			getStateMinor(ID.M.CraneState) == 0)
   		{
   			//get nearby ship
-  			List<EntityDestroyerIkazuchi> slist = this.world.getEntitiesWithinAABB(EntityDestroyerIkazuchi.class, this.getEntityBoundingBox().expand(4D, 4D, 4D));
+  			List<EntityDestroyerIkazuchi> slist = this.world.getEntitiesWithinAABB(EntityDestroyerIkazuchi.class, this.getEntityBoundingBox().grow(4D, 4D, 4D));
 
   			if (slist != null && !slist.isEmpty())
   			{

--- a/src/main/java/com/lulan/shincolle/entity/hime/EntityAirfieldHime.java
+++ b/src/main/java/com/lulan/shincolle/entity/hime/EntityAirfieldHime.java
@@ -83,7 +83,7 @@ public class EntityAirfieldHime extends BasicEntityShipCV
 				{
 					//判定bounding box內是否有可以回血的目標
 					int healCount = this.getLevel() / 15 + 2;
-		            List<EntityLivingBase> hitList = this.world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().expand(12D, 12D, 12D));
+		            List<EntityLivingBase> hitList = this.world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().grow(12D, 12D, 12D));
 		            TargetPoint point = new TargetPoint(this.dimension, this.posX, this.posY, this.posZ, 64D);
 		            
 		            for (EntityLivingBase target : hitList)

--- a/src/main/java/com/lulan/shincolle/entity/hime/EntityBattleshipHime.java
+++ b/src/main/java/com/lulan/shincolle/entity/hime/EntityBattleshipHime.java
@@ -102,7 +102,7 @@ public class EntityBattleshipHime extends BasicEntityShipSmall
   				if (getStateFlag(ID.F.IsMarried) && getStateFlag(ID.F.UseRingEffect) &&
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   	  	  			
   					if (shiplist != null && shiplist.size() > 0)
   					{

--- a/src/main/java/com/lulan/shincolle/entity/hime/EntityCAHime.java
+++ b/src/main/java/com/lulan/shincolle/entity/hime/EntityCAHime.java
@@ -186,7 +186,7 @@ public class EntityCAHime extends BasicEntityShipSmall
     //find target to push
     private void findTargetPush()
     {
-        AxisAlignedBB impactBox = this.getEntityBoundingBox().expand(12D, 6D, 12D); 
+        AxisAlignedBB impactBox = this.getEntityBoundingBox().grow(12D, 6D, 12D); 
         List<EntityLivingBase> list = this.world.getEntitiesWithinAABB(EntityLivingBase.class, impactBox);
         
         //valid entity

--- a/src/main/java/com/lulan/shincolle/entity/hime/EntityCarrierHime.java
+++ b/src/main/java/com/lulan/shincolle/entity/hime/EntityCarrierHime.java
@@ -79,7 +79,7 @@ public class EntityCarrierHime extends BasicEntityShipCV
   				if (getStateFlag(ID.F.IsMarried) && getStateFlag(ID.F.UseRingEffect) &&
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   	  	  			
   					if (shiplist != null && shiplist.size() > 0)
   					{

--- a/src/main/java/com/lulan/shincolle/entity/hime/EntityCarrierWD.java
+++ b/src/main/java/com/lulan/shincolle/entity/hime/EntityCarrierWD.java
@@ -83,7 +83,7 @@ public class EntityCarrierWD extends BasicEntityShipCV
   				if (getStateFlag(ID.F.IsMarried) && getStateFlag(ID.F.UseRingEffect) &&
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   	  	  			
   					if (shiplist != null && shiplist.size() > 0)
   					{

--- a/src/main/java/com/lulan/shincolle/entity/hime/EntityHarbourHime.java
+++ b/src/main/java/com/lulan/shincolle/entity/hime/EntityHarbourHime.java
@@ -84,7 +84,7 @@ public class EntityHarbourHime extends BasicEntityShipCV
 				{
 					//判定bounding box內是否有可以回血的目標
 					int healCount = this.getLevel() / 50 + 1;
-		            List<EntityLivingBase> hitList = this.world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().expand(12D, 12D, 12D));
+		            List<EntityLivingBase> hitList = this.world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().grow(12D, 12D, 12D));
 		            TargetPoint point = new TargetPoint(this.dimension, this.posX, this.posY, this.posZ, 64D);
 		            
 		            for (EntityLivingBase target : hitList)

--- a/src/main/java/com/lulan/shincolle/entity/hime/EntityMidwayHime.java
+++ b/src/main/java/com/lulan/shincolle/entity/hime/EntityMidwayHime.java
@@ -82,7 +82,7 @@ public class EntityMidwayHime extends BasicEntityShipCV
   					getStateMinor(ID.M.NumGrudge) > 0)
   				{
   					//apply buff to nearby ships
-  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(16D, 16D, 16D));
+  					List<BasicEntityShip> shiplist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(16D, 16D, 16D));
   					if (shiplist != null && shiplist.size() > 0)
   					{
   						for (BasicEntityShip s : shiplist)

--- a/src/main/java/com/lulan/shincolle/entity/hime/EntityNorthernHime.java
+++ b/src/main/java/com/lulan/shincolle/entity/hime/EntityNorthernHime.java
@@ -105,7 +105,7 @@ public class EntityNorthernHime extends BasicEntityShipCV
 				{
 					//判定bounding box內是否有可以回血的目標
 					int healCount = this.getLevel() / 25 + 1;
-		            List<EntityLivingBase> hitList = this.world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().expand(8D, 8D, 8D));
+		            List<EntityLivingBase> hitList = this.world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().grow(8D, 8D, 8D));
 		            TargetPoint point = new TargetPoint(this.dimension, this.posX, this.posY, this.posZ, 64D);
 		            
 		            for (EntityLivingBase target : hitList)
@@ -246,7 +246,7 @@ public class EntityNorthernHime extends BasicEntityShipCV
 		}
 		else
 		{
-	        List<EntityLivingBase> hitList = this.world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().expand(6D, 4D, 6D));
+	        List<EntityLivingBase> hitList = this.world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().grow(6D, 4D, 6D));
 	        
 	        hitList.removeIf(target ->
 	        	!(target instanceof BasicEntityShip || target instanceof EntityPlayer) ||

--- a/src/main/java/com/lulan/shincolle/entity/hime/EntitySSNH.java
+++ b/src/main/java/com/lulan/shincolle/entity/hime/EntitySSNH.java
@@ -358,7 +358,7 @@ public class EntitySSNH extends BasicEntityShipSmall implements IShipInvisible
 		}
 		else
 		{
-	        List<EntityLivingBase> hitList = this.world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().expand(6D, 4D, 6D));
+	        List<EntityLivingBase> hitList = this.world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().grow(6D, 4D, 6D));
 	        
 	        hitList.removeIf(target ->
 	        	!(target instanceof BasicEntityShip || target instanceof EntityPlayer) ||

--- a/src/main/java/com/lulan/shincolle/entity/other/EntityAbyssMissile.java
+++ b/src/main/java/com/lulan/shincolle/entity/other/EntityAbyssMissile.java
@@ -393,7 +393,7 @@ public class EntityAbyssMissile extends Entity implements IShipOwner, IShipAttrs
                 }
                 
                 //碰撞判定3: 擴展AABB碰撞: missile擴展1格大小內是否有entity可觸發爆炸
-                List<Entity> hitList = this.world.getEntitiesWithinAABB(Entity.class, this.getEntityBoundingBox().expand(1D, 1.5D, 1D));
+                List<Entity> hitList = this.world.getEntitiesWithinAABB(Entity.class, this.getEntityBoundingBox().grow(1D, 1.5D, 1D));
                 
                 //搜尋list, 找出第一個可以判定的目標, 即傳給onImpact
                 for (Entity ent : hitList)
@@ -618,7 +618,7 @@ public class EntityAbyssMissile extends Entity implements IShipOwner, IShipAttrs
     		
             //計算範圍爆炸傷害: 判定bounding box內是否有可以吃傷害的entity
             List<Entity> hitList = this.world.getEntitiesWithinAABB(Entity.class,
-            						this.getEntityBoundingBox().expand(3.5D, 3.5D, 3.5D));
+            						this.getEntityBoundingBox().grow(3.5D, 3.5D, 3.5D));
             
             //對list中所有可攻擊entity做出傷害判定
             for (Entity ent : hitList)

--- a/src/main/java/com/lulan/shincolle/entity/other/EntityFloatingFort.java
+++ b/src/main/java/com/lulan/shincolle/entity/other/EntityFloatingFort.java
@@ -167,7 +167,7 @@ public class EntityFloatingFort extends BasicEntityAirplane
 		
 		//calc miss chance, if not miss, calc cri/multi hit
 		//計算範圍爆炸傷害: 判定bounding box內是否有可以吃傷害的entity
-        List<Entity> hitList = this.world.getEntitiesWithinAABB(Entity.class, this.getEntityBoundingBox().expand(4.5D, 4.5D, 4.5D));
+        List<Entity> hitList = this.world.getEntitiesWithinAABB(Entity.class, this.getEntityBoundingBox().grow(4.5D, 4.5D, 4.5D));
         float atk;
         
         //搜尋list, 找出第一個可以判定的目標, 即傳給onImpact

--- a/src/main/java/com/lulan/shincolle/entity/other/EntityProjectileBeam.java
+++ b/src/main/java/com/lulan/shincolle/entity/other/EntityProjectileBeam.java
@@ -175,7 +175,7 @@ public class EntityProjectileBeam extends Entity implements IShipOwner, IShipAtt
         	
     		//判定bounding box內是否有可以觸發爆炸的entity
             List<Entity> hitList = this.world.getEntitiesWithinAABB(Entity.class,
-            								this.getEntityBoundingBox().expand(1.5D, 1.5D, 1.5D));
+            								this.getEntityBoundingBox().grow(1.5D, 1.5D, 1.5D));
             
             //搜尋list, 找出可碰撞目標執行onImpact
             for (Entity ent : hitList)

--- a/src/main/java/com/lulan/shincolle/entity/other/EntityProjectileStatic.java
+++ b/src/main/java/com/lulan/shincolle/entity/other/EntityProjectileStatic.java
@@ -157,7 +157,7 @@ public class EntityProjectileStatic extends Entity implements IShipOwner, IShipA
     			{
     				//判定bounding box內是否有可以觸發爆炸的entity
                     List<Entity> hitList = this.world.getEntitiesWithinAABB(Entity.class,
-                    								this.getEntityBoundingBox().expand(this.range, this.range, this.range));
+                    								this.getEntityBoundingBox().grow(this.range, this.range, this.range));
                     
                     //pull entity whose distance > 1D
                     for (Entity ent : hitList)

--- a/src/main/java/com/lulan/shincolle/entity/transport/EntityTransportWa.java
+++ b/src/main/java/com/lulan/shincolle/entity/transport/EntityTransportWa.java
@@ -114,7 +114,7 @@ public class EntityTransportWa extends BasicEntityShipSmall
 		            TargetPoint point = new TargetPoint(this.dimension, this.posX, this.posY, this.posZ, 64D);
 
 		            //get nearby ships
-		            slist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().expand(range, range, range));
+		            slist = this.world.getEntitiesWithinAABB(BasicEntityShip.class, this.getEntityBoundingBox().grow(range, range, range));
 
 		            for (BasicEntityShip s : slist)
 		            {

--- a/src/main/java/com/lulan/shincolle/item/CombatRation.java
+++ b/src/main/java/com/lulan/shincolle/item/CombatRation.java
@@ -165,7 +165,7 @@ public class CombatRation extends BasicItem implements IShipCombatRation
 				if (inUse && (player.ticksExisted & 15) == 0)
 				{
 					//get nearby ship
-		  			List<BasicEntityShip> slist = world.getEntitiesWithinAABB(BasicEntityShip.class, player.getEntityBoundingBox().expand(8D, 6D, 8D));
+		  			List<BasicEntityShip> slist = world.getEntitiesWithinAABB(BasicEntityShip.class, player.getEntityBoundingBox().grow(8D, 6D, 8D));
 
 	              	for (BasicEntityShip s : slist)
 	              	{

--- a/src/main/java/com/lulan/shincolle/item/MarriageRing.java
+++ b/src/main/java/com/lulan/shincolle/item/MarriageRing.java
@@ -150,7 +150,7 @@ public class MarriageRing extends BasicItem implements IBauble
 				if (inUse && slot != 0 && (entity.ticksExisted & 63) == 0)
 				{
 					//apply shy emotion to nearby ship
-		  			List<BasicEntityShip> slist = world.getEntitiesWithinAABB(BasicEntityShip.class, entity.getEntityBoundingBox().expand(6D, 5D, 6D));
+		  			List<BasicEntityShip> slist = world.getEntitiesWithinAABB(BasicEntityShip.class, entity.getEntityBoundingBox().grow(6D, 5D, 6D));
 
 	              	for (BasicEntityShip s : slist)
 	              	{

--- a/src/main/java/com/lulan/shincolle/utility/BuffHelper.java
+++ b/src/main/java/com/lulan/shincolle/utility/BuffHelper.java
@@ -601,7 +601,7 @@ public class BuffHelper
 		
 		//check cloud entities
 		List<EntityAreaEffectCloud> getlist = host.world.getEntitiesWithinAABB(
-				EntityAreaEffectCloud.class, host.getEntityBoundingBox().expand(3D, 3D, 3D));
+				EntityAreaEffectCloud.class, host.getEntityBoundingBox().grow(3D, 3D, 3D));
 		
 		if (!getlist.isEmpty())
 		{
@@ -628,7 +628,7 @@ public class BuffHelper
 		
 		//check potion entities
 		List<EntityPotion> getlist2 = host.world.getEntitiesWithinAABB(
-				EntityPotion.class, host.getEntityBoundingBox().expand(3D, 3D, 3D));
+				EntityPotion.class, host.getEntityBoundingBox().grow(3D, 3D, 3D));
 		
 		if (!getlist2.isEmpty())
 		{

--- a/src/main/java/com/lulan/shincolle/utility/EntityHelper.java
+++ b/src/main/java/com/lulan/shincolle/utility/EntityHelper.java
@@ -791,7 +791,7 @@ public class EntityHelper
             Entity pointedEntity = null;
             
             //從玩家到目標方塊之間, 做出擴展1格的方形collision box, 抓出其中碰到的entity
-            List<Entity> list = viewer.world.getEntitiesWithinAABBExcludingEntity(viewer, viewer.getEntityBoundingBox().grow(vec3x, vec3y, vec3z).expand(1D, 1D, 1D));
+            List<Entity> list = viewer.world.getEntitiesWithinAABBExcludingEntity(viewer, viewer.getEntityBoundingBox().grow(vec3x, vec3y, vec3z).grow(1D, 1D, 1D));
             double d2 = d1;
 
             //檢查抓到的entity, 是否在玩家~目標方塊的視線上
@@ -824,7 +824,7 @@ public class EntityHelper
                 {
                 	//檢查entity大小是否在視線上碰撞到
                     double f2 = entity.getCollisionBorderSize();
-                    AxisAlignedBB targetBox = entity.getEntityBoundingBox().expand(f2, f2, f2);
+                    AxisAlignedBB targetBox = entity.getEntityBoundingBox().grow(f2, f2, f2);
                     RayTraceResult getObj = targetBox.calculateIntercept(vec3, vec32);
 
                     //若viewer完全塞在目標的box裡面

--- a/src/main/java/com/lulan/shincolle/utility/PacketHelper.java
+++ b/src/main/java/com/lulan/shincolle/utility/PacketHelper.java
@@ -879,7 +879,7 @@ public class PacketHelper
     	{
     		//get entity item nearby player
     		float[] data = null;	//k:x, k+1:y, k+2:z
-    		List<BasicEntityItem> getlist = player.world.getEntitiesWithinAABB(BasicEntityItem.class, player.getEntityBoundingBox().expand(128D, 256D, 128D));
+    		List<BasicEntityItem> getlist = player.world.getEntitiesWithinAABB(BasicEntityItem.class, player.getEntityBoundingBox().grow(128D, 256D, 128D));
     		
     		if (getlist.size() > 0)
     		{

--- a/src/main/java/com/lulan/shincolle/utility/TargetHelper.java
+++ b/src/main/java/com/lulan/shincolle/utility/TargetHelper.java
@@ -566,7 +566,7 @@ public class TargetHelper
 		{
 			//get ship
 			List<BasicEntityShip> list1 = player.world.getEntitiesWithinAABB(BasicEntityShip.class,
-					player.getEntityBoundingBox().expand(dist, dist, dist));
+					player.getEntityBoundingBox().grow(dist, dist, dist));
 			
 			if (list1 != null && !list1.isEmpty())
 			{
@@ -590,7 +590,7 @@ public class TargetHelper
 		{
 			//get hostile ship
 			List<BasicEntityShipHostile> list1 = host.world.getEntitiesWithinAABB(BasicEntityShipHostile.class,
-					host.getEntityBoundingBox().expand(dist, dist, dist));
+					host.getEntityBoundingBox().grow(dist, dist, dist));
 			
 			if (list1 != null && !list1.isEmpty())
 			{

--- a/src/main/java/com/lulan/shincolle/utility/TaskHelper.java
+++ b/src/main/java/com/lulan/shincolle/utility/TaskHelper.java
@@ -1123,7 +1123,7 @@ public class TaskHelper
 			bot = ship.getCapaShipInventory().getStackInSlot(botid);
 			
 			//find xp orb
-			List<EntityXPOrb> getlist = ship.world.getEntitiesWithinAABB(EntityXPOrb.class, ship.getEntityBoundingBox().expand(7D, 7D, 7D));
+			List<EntityXPOrb> getlist = ship.world.getEntitiesWithinAABB(EntityXPOrb.class, ship.getEntityBoundingBox().grow(7D, 7D, 7D));
 			
 			if (getlist.size() > 0)
 			{


### PR DESCRIPTION
While playing this mod I encountered a weird bug that my kanmusu sometimes does not attack nearby enemies. After investigation I found that it was possibly caused by `AxisAlignedBB.expand`.

From documentation, expand:
```java
     * Creates a new {@link AxisAlignedBB} that has been expanded by the given amount, with positive changes increasing
     * max values and negative changes decreasing min values.
```
and example:
`new AxisAlignedBB(0, 0, 0, 1, 1, 1).expand(2, 2, 2)` results in `box[0, 0, 0 -> 3, 3, 3]`.
While looking for targets, the bounding box was only expanded in positive direction. Therefore, if the enemy is in the negative direction relative to the kanmusu, the kanmusu will never target the enemy automatically. (except revenge, player attack, etc.)

I think it's more reasonable to use `AxisAlignedBB.grow` instead:
```java
     * Creates a new {@link AxisAlignedBB} that has been contracted by the given amount in both directions. Negative
     * values will shrink the AABB instead of expanding it.
```

I noticed that `AxisAlignedBB.grow` does not seem to be available on mc 1.7. I'm wondering if that's a new API in mc 1.12? I breifly reviewed all use cases of `AxisAlignedBB.expand` and they all seem to mean to be `AxisAlignedBB.grow`. Please correct me if I'm wrong or there are some special cases that I ignored. I don't see any reason to only expand in the positive direction for all these usages.

Therefore, I replaced all `AxisAlignedBB.expand` with `AxisAlignedBB.grow` in this PR. (There are also some whitespace changes because of my IDE noticing mixed tabs and spaces) This fixes the problem and allows kanmusu to attack nearby enemies in both positive and negative direction.