### PR TITLE
Fix for some items becoming invisible when certain mods are present

### DIFF
--- a/src/main/java/com/lulan/shincolle/client/render/item/RenderTileEntityItem.java
+++ b/src/main/java/com/lulan/shincolle/client/render/item/RenderTileEntityItem.java
@@ -1,13 +1,13 @@
 package com.lulan.shincolle.client.render.item;
 
 import com.lulan.shincolle.init.ModBlocks;
-import com.lulan.shincolle.tileentity.TileEntityDesk;
-import com.lulan.shincolle.tileentity.TileEntitySmallShipyard;
-import net.minecraft.block.Block;
-import net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer;
-import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
+import com.lulan.shincolle.tileentity.TileEntityDesk;
+import com.lulan.shincolle.tileentity.TileEntitySmallShipyard;
+import net.minecraft.client.renderer.tileentity.TileEntityItemStackRenderer;
+import net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher;
 
 /** tile entity itemblock renderer
  *
@@ -18,31 +18,50 @@ import net.minecraft.tileentity.TileEntity;
  */
 public class RenderTileEntityItem extends TileEntityItemStackRenderer
 {
+	private static final TileEntity SmallShipyard = new TileEntitySmallShipyard();
+	private static final TileEntity Desk = new TileEntityDesk();
+	private final TileEntityItemStackRenderer parent;
+
+	public RenderTileEntityItem(TileEntityItemStackRenderer parent) {
+		this.parent = parent;
+	}
 	
-	private static TileEntity SmallShipyard = new TileEntitySmallShipyard();
-	private static TileEntity Desk = new TileEntityDesk();
-	
-	
-    @Override
-    public void renderByItem(ItemStack itemStack)
-    {
-        Block block = Block.getBlockFromItem(itemStack.getItem());
-        
-        //mod特製模型的tile entity
-        if (block == ModBlocks.BlockSmallShipyard)
-        {
+	@Override
+	public void renderByItem(ItemStack itemStack)
+	{
+		//load tile entity as item model
+		if (itemStack.getItem() == Item.getItemFromBlock(ModBlocks.BlockSmallShipyard))
+		{
 			TileEntityRendererDispatcher.instance.render(SmallShipyard, 0D, 0D, 0D, 0F);
-        }
-        else if (block == ModBlocks.BlockDesk)
-        {
+		}
+		else if (itemStack.getItem() == Item.getItemFromBlock(ModBlocks.BlockDesk))
+		{
 			TileEntityRendererDispatcher.instance.render(Desk, 0D, 0D, 0D, 0F);
-        }
-        //其他mc的tile entity
-        else
-        {
-            super.renderByItem(itemStack);
-        }
-    }
-    
-    
+		}
+		//if neither of the above, render item normally
+		else
+		{
+			parent.renderByItem(itemStack);
+		}
+	}
+	
+	@Override
+	public void renderByItem(ItemStack itemStack, float partialTicks)
+	{
+		//load tile entity as item model
+		if (itemStack.getItem() == Item.getItemFromBlock(ModBlocks.BlockSmallShipyard))
+		{
+			TileEntityRendererDispatcher.instance.render(SmallShipyard, 0D, 0D, 0D, 0F);
+		}
+		else if (itemStack.getItem() == Item.getItemFromBlock(ModBlocks.BlockDesk))
+		{
+			TileEntityRendererDispatcher.instance.render(Desk, 0D, 0D, 0D, 0F);
+		}
+		//if neither of the above, render item normally
+		else
+		{
+			parent.renderByItem(itemStack, partialTicks);
+		}
+	}
+	
 }

--- a/src/main/java/com/lulan/shincolle/proxy/ClientProxy.java
+++ b/src/main/java/com/lulan/shincolle/proxy/ClientProxy.java
@@ -89,7 +89,7 @@ public class ClientProxy extends CommonProxy
 	public void registerRender() throws Exception
 	{
 		//取代mc原本的tesr item renderer, 改為自訂的renderer
-		TileEntityItemStackRenderer.instance = new RenderTileEntityItem();
+		TileEntityItemStackRenderer.instance = new RenderTileEntityItem(TileEntityItemStackRenderer.instance);
 		
 		//custom item entity render
 		RenderingRegistry.registerEntityRenderingHandler(BasicEntityItem.class, RenderBasicEntityItem.FACTORY);


### PR DESCRIPTION
Fixes an issue which occurs when certain mods (e.g. Botania) are running alongside Shincolle, in which both the Admiral's Desk and the Hydrothermal Vent will become invisible when being rendered as an item (in the inventory, while being held, when dropped, etc).

I've also included a fix for the way Shincolle's TileEntityItemStackRenderer is called in ClientProxy.java, which would substitute the current renderer without linking back to it, potentially causing problems in other mods' ability to render their own tile entity items.

Despite my best efforts I still haven't found a way to fix the issue which turns these same items invisible when BlackHoleStorage is present, so I apologise if I stumble upon it soon and open another pull request in the near future.